### PR TITLE
Fixed DS1302::begin() won't work

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -329,7 +329,7 @@ uint8_t DS1302::begin(void) {
 	pinMode(io, INPUT);
 	write(7,0);
 	uint8_t sec = read(0);
-	sec |= (1 << 7);
+	sec &= 0x7F;
 	write(0, sec);
 	return 1;
 }


### PR DESCRIPTION
According to DS1302's datasheet, 0x80h(second's register)'s MSB is set to 1 on boot, which will make the time pause and is Low Power mode. In order to make the chip start timing, 0x80h's MSB has to be set to 0 to begin the RTC. 